### PR TITLE
v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2019-08-16
+
+Release of 1.0.0 (stable API)
+(messed up 1.0.0 on npm so it's 1.0.1)
+
 ## [1.0.0-beta] - 2019-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ See the [changelog](/CHANGELOG.md) or [releases](https://github.com/oganexon/sec
 
 ## 📌 TODO
 
-- [ ] Release of 1.0.0 (stable API)
+- [x] Release of 1.0.0 (stable API)
 - [ ] Implement more tests
 - [ ] TypeScript
 - [ ] Support of 64bit files

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secure-rm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Completely erases files by making recovery impossible.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secure-rm",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "Completely erases files by making recovery impossible.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## [1.0.1] - 2019-08-16

Release of 1.0.0 (stable API)
(messed up 1.0.0 on npm so it's 1.0.1)
