### PR TITLE
3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.3] - 2019-08-30
+
+### Fixed
+- Default standard when none is provided. (Tests are now a priority)
+
 ## [3.0.2] - 2019-08-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "secure-rm",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secure-rm",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Completely erases files by making recovery impossible.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/secure-rm.ts
+++ b/src/secure-rm.ts
@@ -31,6 +31,7 @@ export function unlink(path: string, options?: Options | Callback, callback?: Ca
     options = { standard: 'secure' }
   }
   // Define standard if none is provided
+  if (options === undefined) options = { standard: 'secure' }
   if ((options as Options).standard === undefined) (options as Options).standard = 'secure'
 
   if (callback) unlinkCallback(path, options as ParsedOptions, (err: NodeJS.ErrnoException | null, path: string) => callback!(err, path))


### PR DESCRIPTION
## [3.0.3] - 2019-08-30

### Fixed
- Default standard when none is provided. (Tests are now a priority)